### PR TITLE
chore: track pipelex keyword-only refactor + migrate to PipelexMTHDSProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+- Track the `pipelex` keyword-only-arguments refactor branch via a temporary `[tool.uv.sources]` git pin (non-subject function parameters across the `pipelex/` public surface are now keyword-only).
+- Migrate `my_project/hello_world.py` to the renamed runtime API: `PipelexRunner` → `PipelexMTHDSProtocol`, `execute_pipeline()` → `execute()` (`PipelexRunner` was removed upstream when the runner became the MTHDS Protocol implementation).
+
 ## [v0.9.0] - 2026-06-06
 
 - Bump `pipelex` to `v0.32.0`: See `Pipelex` changelog [here](https://docs.pipelex.com/latest/changelog/)

--- a/my_project/hello_world.py
+++ b/my_project/hello_world.py
@@ -2,7 +2,7 @@ import asyncio
 
 from pipelex import pretty_print
 from pipelex.pipelex import Pipelex
-from pipelex.pipeline.runner import PipelexRunner
+from pipelex.pipeline.runner import PipelexMTHDSProtocol
 
 
 async def hello_world():
@@ -10,8 +10,8 @@ async def hello_world():
     This function demonstrates the use of a super simple Pipelex pipeline to generate text.
     """
     # Run the pipe
-    runner = PipelexRunner()
-    response = await runner.execute_pipeline(
+    runner = PipelexMTHDSProtocol()
+    response = await runner.execute(
         pipe_code="hello_world",
     )
     pipe_output = response.pipe_output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ required-version = ">=0.7.2"
 
 [tool.uv.sources]
 # Temporary: track the keyword-only-arguments refactor branch of pipelex until it is released to PyPI.
-pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "755b82117fd4c26ba090455cfd571099cf05708b" }
+pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "0e32c8c02600e17bbe146331f9b701ccc03a1ca1" }
 
 [tool.mypy]
 packages = ["my_project"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ required-version = ">=0.7.2"
 
 [tool.uv.sources]
 # Temporary: track the keyword-only-arguments refactor branch of pipelex until it is released to PyPI.
-pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "529b908255e0eb513038a2d92a58730185a22b74" }
+pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "755b82117fd4c26ba090455cfd571099cf05708b" }
 
 [tool.mypy]
 packages = ["my_project"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ Documentation = "https://docs.pipelex.com/"
 [tool.uv]
 required-version = ">=0.7.2"
 
+[tool.uv.sources]
+# Temporary: track the keyword-only-arguments refactor branch of pipelex until it is released to PyPI.
+pipelex = { git = "https://github.com/Pipelex/pipelex.git", rev = "529b908255e0eb513038a2d92a58730185a22b74" }
+
 [tool.mypy]
 packages = ["my_project"]
 check_untyped_defs = true

--- a/uv.lock
+++ b/uv.lock
@@ -1761,7 +1761,7 @@ dev = [
 requires-dist = [
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal"], git = "https://github.com/Pipelex/pipelex.git?rev=529b908255e0eb513038a2d92a58730185a22b74" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal"], git = "https://github.com/Pipelex/pipelex.git?rev=755b82117fd4c26ba090455cfd571099cf05708b" },
     { name = "pipelex-tools", marker = "extra == 'dev'", specifier = ">=0.3.2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.410" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
@@ -2245,7 +2245,7 @@ wheels = [
 [[package]]
 name = "pipelex"
 version = "0.33.0"
-source = { git = "https://github.com/Pipelex/pipelex.git?rev=529b908255e0eb513038a2d92a58730185a22b74#529b908255e0eb513038a2d92a58730185a22b74" }
+source = { git = "https://github.com/Pipelex/pipelex.git?rev=755b82117fd4c26ba090455cfd571099cf05708b#755b82117fd4c26ba090455cfd571099cf05708b" }
 dependencies = [
     { name = "aiofiles" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1761,7 +1761,7 @@ dev = [
 requires-dist = [
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal"], git = "https://github.com/Pipelex/pipelex.git?rev=755b82117fd4c26ba090455cfd571099cf05708b" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal"], git = "https://github.com/Pipelex/pipelex.git?rev=0e32c8c02600e17bbe146331f9b701ccc03a1ca1" },
     { name = "pipelex-tools", marker = "extra == 'dev'", specifier = ">=0.3.2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.410" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
@@ -2245,7 +2245,7 @@ wheels = [
 [[package]]
 name = "pipelex"
 version = "0.33.0"
-source = { git = "https://github.com/Pipelex/pipelex.git?rev=755b82117fd4c26ba090455cfd571099cf05708b#755b82117fd4c26ba090455cfd571099cf05708b" }
+source = { git = "https://github.com/Pipelex/pipelex.git?rev=0e32c8c02600e17bbe146331f9b701ccc03a1ca1#0e32c8c02600e17bbe146331f9b701ccc03a1ca1" }
 dependencies = [
     { name = "aiofiles" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1284,14 +1284,15 @@ wheels = [
 
 [[package]]
 name = "kajson"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
+    { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/54/83c3b00f270c39037b699398e42e16837ef1109c8af47ac668fe3c14a817/kajson-0.6.0.tar.gz", hash = "sha256:7544a544e6f135f129015c9475ff2cc0a7fc8e76d6eea1d8d37f2e438ab4d936", size = 22567, upload-time = "2026-05-30T19:06:08.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/a4/da91af6dac42516e45a9897ba901d8ec2ee2b13b135caf6ce120867aac2b/kajson-0.7.0.tar.gz", hash = "sha256:1c8f80d157f980c9adb9fda0e77c1cc0078f50547d84ef548a5e19b5a84d8d37", size = 25071, upload-time = "2026-06-10T10:00:56.097Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/fb/e325ef3bd84f2d40286a09fe78447a0a20e3a6ec12ce28e0d4ecc8bce620/kajson-0.6.0-py3-none-any.whl", hash = "sha256:77ddb0e12b274479ced061d84da091a250fdeb3f4dd7444ae0c6ca929ba73431", size = 29024, upload-time = "2026-05-30T19:06:06.645Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/1c/8251c0dadd1843e020edf4ef162aaa7dd0e98cbd2e1fe33d843807cd7ce9/kajson-0.7.0-py3-none-any.whl", hash = "sha256:d9903327bc7f182ec481ffafd074765347365600592e5f9f67866d5b0ae4f939", size = 31524, upload-time = "2026-06-10T10:00:54.952Z" },
 ]
 
 [[package]]
@@ -1576,7 +1577,7 @@ wheels = [
 
 [[package]]
 name = "mthds"
-version = "0.3.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
@@ -1587,9 +1588,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/3c/eea615b49c011657246ff61371ca4a95ab3baa94d4b79541bd4b0f816ae5/mthds-0.3.0.tar.gz", hash = "sha256:de479f977b2ec3614b23bdb53ed3e28e2332a2f1653ee92e118c530fe3d5d820", size = 112693, upload-time = "2026-04-29T12:50:11.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/fc/7822e39bc733f5f62577ea1d064c7283d84b97493e5372ceb430ce0c1027/mthds-0.4.1.tar.gz", hash = "sha256:1aa43860fef97aeab561473e45552ea619dee7c624bc4acad806dd960bb2fe5f", size = 132336, upload-time = "2026-06-11T21:46:28.332Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/86/1184f31583d3089baea9316853b329720cb786d8e01f38f303a17f1e3f4c/mthds-0.3.0-py3-none-any.whl", hash = "sha256:3f9822c23beb82607ec4bafcff99717fb6531eed8d19b86086dc9deb7825b06b", size = 49356, upload-time = "2026-04-29T12:50:09.734Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/92/8d6521c63e71fc4b782d7a875b27ad5b61cf1af718eb3321a3522aa33391/mthds-0.4.1-py3-none-any.whl", hash = "sha256:fdbf4ec25f4139b620cf5771fb8dc9fa27c2c249c161ca96afac389f2cfc6d4f", size = 61176, upload-time = "2026-06-11T21:46:26.978Z" },
 ]
 
 [[package]]
@@ -1760,7 +1761,7 @@ dev = [
 requires-dist = [
     { name = "boto3-stubs", marker = "extra == 'dev'", specifier = ">=1.35.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal"], specifier = ">=0.32.0" },
+    { name = "pipelex", extras = ["mistralai", "anthropic", "google", "google-genai", "bedrock", "fal"], git = "https://github.com/Pipelex/pipelex.git?rev=529b908255e0eb513038a2d92a58730185a22b74" },
     { name = "pipelex-tools", marker = "extra == 'dev'", specifier = ">=0.3.2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.410" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
@@ -2243,8 +2244,8 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.32.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.33.0"
+source = { git = "https://github.com/Pipelex/pipelex.git?rev=529b908255e0eb513038a2d92a58730185a22b74#529b908255e0eb513038a2d92a58730185a22b74" }
 dependencies = [
     { name = "aiofiles" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
@@ -2284,10 +2285,6 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
     { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/1d/dd5a2a3a6d32b1bfb21704d70725f63c2777e54884545ef4238baf804fd4/pipelex-0.32.0.tar.gz", hash = "sha256:b2345ea2bedf1d37271bb5f2b70a4ed2e05f00288e5f05428bf5eb6d0223dacf", size = 973434, upload-time = "2026-06-09T11:04:45.623Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/4a/099b5d494754f3b778ff1bd0f322dd638b6dd2b734bb1ab7a82a36773b42/pipelex-0.32.0-py3-none-any.whl", hash = "sha256:0accfd957e25922209a1a79d78c53891bef16515ad527d73e86ed838a6afb205", size = 1394760, upload-time = "2026-06-09T11:04:43.306Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What

Pins this starter template to the pipelex **keyword-only-arguments refactor** branch (`refactor/Function-calling-4`) to validate it in lockstep, and migrates the sample app off the removed `PipelexRunner` class.

## Changes

- **`pyproject.toml` / `uv.lock`**: add a temporary `[tool.uv.sources]` git pin for `pipelex` at rev `529b9082`.
- **`my_project/hello_world.py`**: `PipelexRunner` → `PipelexMTHDSProtocol`, `execute_pipeline()` → `execute()`. The runner class was renamed upstream when it became the MTHDS Protocol implementation (`PipelexRunner` removed; `execute_pipeline`→`execute`). `response.pipe_output` is unchanged.
- **`CHANGELOG.md`**: `[Unreleased]` entry.

## Why both changes

The pinned PyPI `pipelex` (0.32.x) still had `PipelexRunner`. Pinning to the branch (which tracks pipelex `dev`) surfaces the already-landed runtime-runner rename in addition to the keyword-only work, so the sample app needs the rename to keep building.

## Verification

Local, all green: `make agent-check`, `make agent-test`, `uv lock --locked`.

## Note

The git-rev pin is **temporary** — swap it back to a released `pipelex` version (`>=`) once the keyword-only refactor lands on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Pipelex/pipelex-starter-python/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

